### PR TITLE
Fix for fatalization of calling import/unimport method with argument

### DIFF
--- a/lib/Parallel/Benchmark.pm
+++ b/lib/Parallel/Benchmark.pm
@@ -6,7 +6,7 @@ our $VERSION = '0.10';
 use Mouse;
 use Log::Minimal;
 use Time::HiRes qw/ tv_interval gettimeofday /;
-use Parallel::ForkManager "1.12";
+use Parallel::ForkManager 1.12;
 use Parallel::Scoreboard;
 use File::Temp qw/ tempdir /;
 use POSIX qw/ SIGUSR1 SIGUSR2 SIGTERM /;


### PR DESCRIPTION
refs
- https://github.com/Perl/perl5/issues/23623
- https://github.com/fujiwara/p5-Parallel-Benchmark/issues/2

> Attempt to call undefined import method with arguments ("1.12") via package "Parallel::ForkManager" (Perhaps you forgot to load the package?)